### PR TITLE
Use built in animation

### DIFF
--- a/app/src/main/java/com/example/android/swipedismiss/MainActivity.java
+++ b/app/src/main/java/com/example/android/swipedismiss/MainActivity.java
@@ -101,12 +101,9 @@ public class MainActivity extends Activity {
                             }
 
                             @Override
-                            public void onDismiss(RecyclerView recyclerView, int[] reverseSortedPositions) {
-                                for (int position : reverseSortedPositions) {
-                                    mItems.remove(position);
-                                }
-                                // do not call notifyItemRemoved for every item, it will cause gaps on deleting items
-                                mAdapter.notifyDataSetChanged();
+                            public void onDismiss(RecyclerView recyclerView, int position) {
+                                mItems.remove(position);
+                                mAdapter.notifyItemRemoved(position);
                             }
                         });
         mRecyclerView.setOnTouchListener(touchListener);

--- a/app/src/main/java/com/example/android/swipedismiss/MainActivity.java
+++ b/app/src/main/java/com/example/android/swipedismiss/MainActivity.java
@@ -19,10 +19,8 @@ package com.example.android.swipedismiss;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
-import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.view.GestureDetector;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -89,9 +87,13 @@ public class MainActivity extends Activity {
         };
         mRecyclerView.setAdapter(mAdapter);
 
+        // Init & set the touch listener
         SwipeDismissRecyclerViewTouchListener touchListener =
                 new SwipeDismissRecyclerViewTouchListener(
                         mRecyclerView,
+                        /**
+                         * Dismiss callback : Handles deletion of item
+                         */
                         new SwipeDismissRecyclerViewTouchListener.DismissCallbacks() {
                             @Override
                             public boolean canDismiss(int position) {
@@ -108,6 +110,7 @@ public class MainActivity extends Activity {
                             }
                         });
         mRecyclerView.setOnTouchListener(touchListener);
+
         // Setting this scroll listener is required to ensure that during ListView scrolling,
         // we don't look for swipes.
         mRecyclerView.setOnScrollListener(touchListener.makeScrollListener());

--- a/app/src/main/java/com/example/android/swipedismiss/MainActivity.java
+++ b/app/src/main/java/com/example/android/swipedismiss/MainActivity.java
@@ -65,10 +65,14 @@ public class MainActivity extends Activity {
 //        mLayoutManager = new StaggeredGridLayoutManager(3, StaggeredGridLayoutManager.VERTICAL);
         mRecyclerView.setLayoutManager(mLayoutManager);
 
+        /**
+         * Regular Adapter
+         * Nothing to see here
+         */
         mAdapter = new RecyclerView.Adapter<CustomViewHolder>() {
             @Override
             public CustomViewHolder onCreateViewHolder(ViewGroup viewGroup, int i) {
-                View view = LayoutInflater.from(viewGroup.getContext()).inflate(android.R.layout.simple_list_item_1
+                View view = LayoutInflater.from(viewGroup.getContext()).inflate(R.layout.list_item
                         , viewGroup, false);
                 return new CustomViewHolder(view);
             }
@@ -116,6 +120,10 @@ public class MainActivity extends Activity {
                 }));
     }
 
+    /**
+     * Regular ViewHolder
+     * Nothing to see here
+     */
     private class CustomViewHolder extends RecyclerView.ViewHolder {
 
         private TextView mTextView;
@@ -123,7 +131,7 @@ public class MainActivity extends Activity {
         public CustomViewHolder(View itemView) {
             super(itemView);
 
-            mTextView = (TextView) itemView.findViewById(android.R.id.text1);
+            mTextView = (TextView) itemView.findViewById(R.id.text_view);
         }
     }
 

--- a/app/src/main/java/com/example/android/swipedismiss/SwipeDismissRecyclerViewTouchListener.java
+++ b/app/src/main/java/com/example/android/swipedismiss/SwipeDismissRecyclerViewTouchListener.java
@@ -125,10 +125,8 @@ public class SwipeDismissRecyclerViewTouchListener implements View.OnTouchListen
         mSlop = vc.getScaledTouchSlop();
         mMinFlingVelocity = vc.getScaledMinimumFlingVelocity() * 16;
         mMaxFlingVelocity = vc.getScaledMaximumFlingVelocity();
-//        mAnimationTime = recyclerView.getContext().getResources().getInteger(
-//                android.R.integer.config_shortAnimTime);
-        // TODO remove test
-        mAnimationTime = 5000;
+        mAnimationTime = recyclerView.getContext().getResources().getInteger(
+                android.R.integer.config_shortAnimTime);
         mRecyclerView = recyclerView;
         mCallbacks = callbacks;
         mHandler = new Handler();
@@ -186,7 +184,6 @@ public class SwipeDismissRecyclerViewTouchListener implements View.OnTouchListen
                 // TODO: ensure this is a finger, and set a flag
 
                 // Find the child view that was touched (perform a hit test)
-                // cf : http://stackoverflow.com/questions/13296162/what-is-the-definition-of-the-value-supplied-by-the-android-function-view-gethit
                 Rect rect = new Rect();
                 int[] listViewCoords = new int[2];
                 mRecyclerView.getLocationOnScreen(listViewCoords);
@@ -220,13 +217,6 @@ public class SwipeDismissRecyclerViewTouchListener implements View.OnTouchListen
                 return false;
             }
 
-            // When is ACTION_CANCEL called ?
-            // -----------------------------
-            // The current gesture has been aborted. You will not receive any more points in it.
-            // You should treat this as an up event, but not perform any action that you normally
-            // would.
-            //
-            // cf : http://stackoverflow.com/questions/11960861/what-causes-a-motionevent-action-cancel-in-android
             case MotionEvent.ACTION_CANCEL: {
                 if (mVelocityTracker == null) {
                     break;
@@ -348,16 +338,11 @@ public class SwipeDismissRecyclerViewTouchListener implements View.OnTouchListen
     }
 
     private void performDismiss(final View dismissView, final int dismissPosition) {
-        // Animate the dismissed list item to zero-height and fire the dismiss callback when
-        // all dismissed list item animations have completed. This triggers layout on each animation
-        // frame; in the future we may want to do something smarter and more performant.
-
         // Trigger callback
         mCallbacks.onDismiss(mRecyclerView, dismissPosition);
 
         // Reset mDownPosition to avoid MotionEvent.ACTION_UP trying to start a dismiss
         // animation with a stale position
-        // (mDownPosition is reset on "ACTION_DOWN")
         mDownPosition = ListView.INVALID_POSITION;
 
         // Send a cancel event

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -23,7 +23,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Bouton 1"
+            android:text="Button 1"
             />
 
         <Button
@@ -31,7 +31,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Bouton 2"
+            android:text="Button 2"
             />
 
     </LinearLayout>

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="40sp"
+        />
+
+    <!-- Linear layout in linear layout, not best practice, but nevermid : Test project -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/button_1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Bouton 1"
+            />
+
+        <Button
+            android:id="@+id/button_2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Bouton 2"
+            />
+
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
Hi,

Instead of using a custom animation in performDismiss(), I used the built in remove animation set in the recyclerView.
This way, no need to track items to delete during animations, and every item is deleted on the spot.
However this method only allow to dismiss ONE item at a time. But I don't see why it would be a problem. I disabled the touchListener when an animation is already running.

Pros : 
- Use built in animation
- No need to track items to delete
- Animation easily customizable
- Works perfectly with all layout managers, not only ListView

Cons : 
- Only one swipe at a time

If I missed something or misunderstood, please let me know.
It's my very first pull request . . . ever. So even if you don't like what I did I would awesome if you could give me a feedback :D 

Anyway thanks for the great work, you have no idea how helpful your project was for me to understand how to implement swipe to dismiss.
